### PR TITLE
Make webapp2_extras/appengine/auth/models.User.validate_token return …

### DIFF
--- a/tests/extras_appengine_auth_models_test.py
+++ b/tests/extras_appengine_auth_models_test.py
@@ -141,14 +141,14 @@ class TestAuthModels(test_base.BaseTestCase):
         auth_id = 'foo'
 
         token = m.create_auth_token(auth_id)
-        self.assertTrue(m.validate_auth_token(auth_id, token))
+        self.assertIsNotNone(m.validate_auth_token(auth_id, token))
         m.delete_auth_token(auth_id, token)
-        self.assertFalse(m.validate_auth_token(auth_id, token))
+        self.assertIsNone(m.validate_auth_token(auth_id, token))
 
         token = m.create_signup_token(auth_id)
-        self.assertTrue(m.validate_signup_token(auth_id, token))
+        self.assertIsNotNone(m.validate_signup_token(auth_id, token))
         m.delete_signup_token(auth_id, token)
-        self.assertFalse(m.validate_signup_token(auth_id, token))
+        self.assertIsNone(m.validate_signup_token(auth_id, token))
 
 
 class TestUniqueModel(test_base.BaseTestCase):

--- a/webapp2_extras/appengine/auth/models.py
+++ b/webapp2_extras/appengine/auth/models.py
@@ -330,7 +330,7 @@ class User(model.Expando):
             A :class:`UserToken` or None if the token does not exist.
         """
         return cls.token_model.get(user=user_id, subject=subject,
-                                   token=token) is not None
+                                   token=token)
 
     @classmethod
     def create_auth_token(cls, user_id):


### PR DESCRIPTION
…UserToken or None.

Make the implementation of webapp2_extras/appengine/auth/models.User.validate_token match
the documentation and return the UserToken instead of Bool. Also correct the unit tests.

This fixes issue #102.