### PR TITLE
Send request headers (cookies) with abort=True requests too.

### DIFF
--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -68,6 +68,7 @@ class RedirectToHandler(webapp2.RequestHandler):
 
 class RedirectAbortHandler(webapp2.RequestHandler):
     def get(self, **kwargs):
+        self.response.headers.add_header('Set-Cookie', 'a=b')
         self.redirect('/somewhere', abort=True)
 
 
@@ -354,6 +355,7 @@ class TestHandler(test_base.BaseTestCase):
 
 The resource was found at http://localhost/somewhere; you should be redirected automatically.  """)
         self.assertEqual(rsp.headers['Location'], 'http://localhost/somewhere')
+        self.assertEqual(rsp.headers['Set-Cookie'], 'a=b')
 
     def test_run(self):
         os.environ['REQUEST_METHOD'] = 'GET'

--- a/webapp2.py
+++ b/webapp2.py
@@ -1800,7 +1800,9 @@ def redirect(uri, permanent=False, abort=False, code=None, body=None,
         'Invalid redirect status code.'
 
     if abort:
-        _abort(code, headers=[('Location', uri)])
+        headers = response.headers.copy() if response is not None else []
+        headers['Location'] = uri
+        _abort(code, headers=headers)
 
     if response is None:
         request = request or get_request()


### PR DESCRIPTION
This should fix https://github.com/GoogleCloudPlatform/webapp2/issues/111