### PR TITLE
Fix link to MultiDict documentation

### DIFF
--- a/docs/guide/request.rst
+++ b/docs/guide/request.rst
@@ -208,4 +208,4 @@ for a detailed API reference and examples.
 
 
 .. _WebOb: http://docs.webob.org/
-.. _MultiDict: http://pythonpaste.org/webob/class-webob.multidict.MultiDict.html
+.. _MultiDict: http://docs.webob.org/en/stable/api/multidict.html


### PR DESCRIPTION
The previous link redirected to http://docs.webob.org/en/latest/class-webob.multidict.MultiDict.html which returned a 404.