### PR TITLE
Make RequestHandler work with Multi-Inheritance

### DIFF
--- a/webapp2.py
+++ b/webapp2.py
@@ -572,6 +572,8 @@ class RequestHandler(object):
             A :class:`Response` instance.
         """
         self.initialize(request, response)
+        super(RequestHandler, self).__init__()
+
 
     def initialize(self, request, response):
         """Initializes this request handler with the given WSGI application,


### PR DESCRIPTION
RequestHandler stops the `__init__` - call chain which keeps initialisation in MixIns from being called.