### PR TITLE
Allow to respond with binary data

### DIFF
--- a/webapp2.py
+++ b/webapp2.py
@@ -416,7 +416,7 @@ class Response(webob.Response):
         """Appends a text to the response body."""
         # webapp uses StringIO as Response.out, so we need to convert anything
         # that is not str or unicode to string to keep same behavior.
-        if not isinstance(text, six.string_types):
+        if not isinstance(text, (six.text_type, six.binary_type)):
             text = str(text)
 
         if isinstance(text, six.text_type) and not self.charset:

--- a/webapp2.py
+++ b/webapp2.py
@@ -416,11 +416,8 @@ class Response(webob.Response):
         """Appends a text to the response body."""
         # webapp uses StringIO as Response.out, so we need to convert anything
         # that is not str or unicode to string to keep same behavior.
-        if six.PY3 and isinstance(text, bytes):
-            text = text.decode(self.default_charset)
-
         if not isinstance(text, six.string_types):
-            text = six.text_type(text)
+            text = str(text)
 
         if isinstance(text, six.text_type) and not self.charset:
             self.charset = self.default_charset


### PR DESCRIPTION
Bring code back to original idea to cast to string any data that not unicode or bytes. It allows user to write bytes to response without double conversion to string and back to bytes.