### PR TITLE
Domain from request

### DIFF
--- a/webapp2.py
+++ b/webapp2.py
@@ -416,11 +416,12 @@ class Response(webob.Response):
         """Appends a text to the response body."""
         # webapp uses StringIO as Response.out, so we need to convert anything
         # that is not str or unicode to string to keep same behavior.
-        if not isinstance(text, six.string_types):
-            text = six.text_type(text)
+        if not isinstance(text, bytes):
+            if not isinstance(text, six.string_types):
+                text = six.text_type(text)
 
-        if isinstance(text, six.text_type) and not self.charset:
-            self.charset = self.default_charset
+            if isinstance(text, six.text_type) and not self.charset:
+                self.charset = self.default_charset
 
         super(Response, self).write(text)
 

--- a/webapp2.py
+++ b/webapp2.py
@@ -416,9 +416,6 @@ class Response(webob.Response):
         """Appends a text to the response body."""
         # webapp uses StringIO as Response.out, so we need to convert anything
         # that is not str or unicode to string to keep same behavior.
-        if six.PY3 and isinstance(text, bytes):
-            text = text.decode(self.default_charset)
-
         if not isinstance(text, six.string_types):
             text = six.text_type(text)
 

--- a/webapp2_extras/routes.py
+++ b/webapp2_extras/routes.py
@@ -108,9 +108,7 @@ class DomainRoute(MultiRoute):
         yield self
 
     def match(self, request):
-        # Use SERVER_NAME to ignore port number that comes with request.host?
-        # host_match = self.regex.match(request.host.split(':', 1)[0])
-        host_match = self.regex.match(request.environ['SERVER_NAME'])
+        host_match = self.regex.match(request.domain)
 
         if host_match:
             args, kwargs = webapp2._get_route_variables(host_match)


### PR DESCRIPTION
The "SERVER_NAME" environment variable seems to be set to an IP address in several environments (paste.httpserver, waitress.serve). But it seems request.domain is set in webob.Request, based on request.host, which preferences environ['HTTP_HOST'] over environ['SERVER_NAME'].