### PR TITLE
Adds support for samesite cookie property to sessions.

### DIFF
--- a/webapp2_extras/sessions.py
+++ b/webapp2_extras/sessions.py
@@ -63,6 +63,9 @@ from webapp2_extras import security
 #:
 #:     - httponly: Disallow JavaScript to access the cookie.
 #:
+#:     - samesite: Strict or Lax. Whether to allow cookies when serving inside a
+#:       frame on another domain.
+#:
 #: backends
 #:     A dictionary of available session backend classes used by
 #:     :meth:`SessionStore.get_session`.
@@ -76,6 +79,7 @@ default_config = {
         'path':        '/',
         'secure':      None,
         'httponly':    False,
+        'samesite':    'Strict'
     },
     'backends': {
         'securecookie': 'webapp2_extras.sessions.SecureCookieSessionFactory',


### PR DESCRIPTION
Currently the webapp2 sessions library library does not allow you set the samesite cookie property using the 'cookie_args' config when initializing the session config. 